### PR TITLE
Reproductions sktime030updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The package is under active development. Currently, classification models based 
 
 Installation
 ------------
-This package uses the base sktime as a dependency. Follow the `original instructions <https://help.github.com/en/articles/changing-a-remotes-url>`__ to install this. 
+This package uses the base sktime as a dependency. Follow the `original instructions <https://github.com/alan-turing-institute/sktime#installation>`__ to install this. 
 
 The sktime-dl package currently has API calls up to date with **sktime version 0.3.0**. Updates to sktime may precede sktime-dl updates by some lag time.
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@ Installation
 ------------
 This package uses the base sktime as a dependency. Follow the `original instructions <https://help.github.com/en/articles/changing-a-remotes-url>`__ to install this. 
 
+The sktime-dl package currently has API calls up to date with **sktime version 0.3.0**. Updates to sktime may precede sktime-dl updates by some lag time.
+
 For the deep-learning part of sktime-dl, you need:
 
 - `Keras <https://github.com/keras-team/keras>`__

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ VERSION = find_version('sktime_dl', '__init__.py')
 INSTALL_REQUIRES = [
     # 'keras_contrib @ git+https://github.com/keras-team/keras-contrib.git@master', # doesn't work with pypi
     # 'keras_contrib', # use once keras_contrib is available on pypi
-    'sktime>=0.2.0',
+    'sktime>=0.3.0',
     'keras>=2.2.4',
     'tensorflow>=1.8.0'  # and/or tensorflow-gpu 1.8.0
 ]

--- a/sktime_dl/classifiers/deeplearning/_cnn.py
+++ b/sktime_dl/classifiers/deeplearning/_cnn.py
@@ -20,7 +20,6 @@ import keras
 import numpy as np
 import pandas as pd
 
-from sktime.utils.validation import check_X_y
 from sktime_dl.classifiers.deeplearning._base import BaseDeepClassifier
 
 
@@ -94,9 +93,7 @@ class CNNClassifier(BaseDeepClassifier):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
-        if input_checks:
-            check_X_y(X, y)
+    def fit(self, X, y, **kwargs):
 
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_encoder.py
+++ b/sktime_dl/classifiers/deeplearning/_encoder.py
@@ -19,7 +19,6 @@ import keras_contrib
 import numpy as np
 import pandas as pd
 
-from sktime.utils.validation import check_X_y
 from sktime_dl.classifiers.deeplearning._base import BaseDeepClassifier
 
 
@@ -91,9 +90,7 @@ class EncoderClassifier(BaseDeepClassifier):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
-        if input_checks:
-            check_X_y(X, y)
+    def fit(self, X, y, **kwargs):
 
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_fcn.py
+++ b/sktime_dl/classifiers/deeplearning/_fcn.py
@@ -18,7 +18,6 @@ import keras
 import numpy as np
 import pandas as pd
 
-from sktime.utils.validation import check_X_y
 from sktime_dl.classifiers.deeplearning._base import BaseDeepClassifier
 
 
@@ -79,9 +78,7 @@ class FCNClassifier(BaseDeepClassifier):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
-        if input_checks:
-            check_X_y(X, y)
+    def fit(self, X, y, **kwargs):
 
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_mcdcnn.py
+++ b/sktime_dl/classifiers/deeplearning/_mcdcnn.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from sklearn.model_selection import train_test_split
 
-from sktime.utils.validation import check_X_y
 from sktime_dl.classifiers.deeplearning._base import BaseDeepClassifier
 
 
@@ -104,9 +103,7 @@ class MCDCNNClassifier(BaseDeepClassifier):
 
         return new_x
 
-    def fit(self, X, y, input_checks=True, **kwargs):
-        if input_checks:
-            check_X_y(X, y)
+    def fit(self, X, y, **kwargs):
 
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_mcnn.py
+++ b/sktime_dl/classifiers/deeplearning/_mcnn.py
@@ -386,7 +386,8 @@ class MCNNClassifier(BaseDeepClassifier):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, **kwargs):
+
         # check and convert input to a univariate Numpy array
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_mlp.py
+++ b/sktime_dl/classifiers/deeplearning/_mlp.py
@@ -18,7 +18,6 @@ import keras
 import numpy as np
 import pandas as pd
 
-from sktime.utils.validation import check_X_y
 from sktime_dl.classifiers.deeplearning._base import BaseDeepClassifier
 
 
@@ -77,9 +76,7 @@ class MLPClassifier(BaseDeepClassifier):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
-        if input_checks:
-            check_X_y(X, y)
+    def fit(self, X, y, **kwargs):
 
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_resnet.py
+++ b/sktime_dl/classifiers/deeplearning/_resnet.py
@@ -18,7 +18,6 @@ import keras
 import numpy as np
 import pandas as pd
 
-from sktime.utils.validation import check_X_y
 from sktime_dl.classifiers.deeplearning._base import BaseDeepClassifier
 
 
@@ -129,9 +128,7 @@ class ResNetClassifier(BaseDeepClassifier):
 
         return model
 
-    def fit(self, X, y, input_checks=True, **kwargs):
-        if input_checks:
-            check_X_y(X, y)
+    def fit(self, X, y, **kwargs):
 
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_tlenet.py
+++ b/sktime_dl/classifiers/deeplearning/_tlenet.py
@@ -168,7 +168,8 @@ class TLENETClassifier(BaseDeepClassifier):
 
         return new_x, new_y, tot_increase_num
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, **kwargs):
+
         # check and convert input to a univariate Numpy array
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/_tuned_cnn.py
+++ b/sktime_dl/classifiers/deeplearning/_tuned_cnn.py
@@ -67,7 +67,7 @@ class TunedCNNClassifier(BaseDeepClassifier):
         else:
             return self.base_model.build_model(input_shape, nb_classes, self.tuned_params)
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, **kwargs):
         if self.search_method is 'grid':
             self.grid = GridSearchCV(estimator=self.base_model,
                                      param_grid=self.param_grid,

--- a/sktime_dl/classifiers/deeplearning/_twiesn.py
+++ b/sktime_dl/classifiers/deeplearning/_twiesn.py
@@ -92,7 +92,8 @@ class TWIESNClassifier(BaseDeepClassifier):
         # argmax the val_y because it is in onehot encoding.
         return accuracy_score(np.argmax(val_y, axis=1), y_pred_val)
 
-    def fit(self, X, y, input_checks=True, **kwargs):
+    def fit(self, X, y, **kwargs):
+
         # check and convert input to a univariate Numpy array
         if isinstance(X, pd.DataFrame):
             if X.shape[1] > 1 or not isinstance(X.iloc[0, 0], pd.Series):

--- a/sktime_dl/classifiers/deeplearning/tests/test_dl4tscnetworks.py
+++ b/sktime_dl/classifiers/deeplearning/tests/test_dl4tscnetworks.py
@@ -145,58 +145,5 @@ def all_networks_all_tests():
         print('\t\t' + network.__class__.__name__ + ' testing finished')
 
 
-def comparisonExperiments():
-    data_dir = sys.argv[1]
-    res_dir = sys.argv[2]
-
-    complete_classifiers = [
-        "dl4tsc_cnn",
-        "dl4tsc_encoder",
-        "dl4tsc_fcn",
-        "dl4tsc_mcdcnn",
-        "dl4tsc_mcnn",
-        "dl4tsc_mlp",
-        "dl4tsc_resnet",
-        "dl4tsc_tlenet",
-        "dl4tsc_twiesn",
-    ]
-
-    small_datasets = [
-        "Beef",
-        "Car",
-        "Coffee",
-        "CricketX",
-        "CricketY",
-        "CricketZ",
-        "DiatomSizeReduction",
-        "Fish",
-        "GunPoint",
-        "ItalyPowerDemand",
-        "MoteStrain",
-        "OliveOil",
-        "Plane",
-        "SonyAIBORobotSurface1",
-        "SonyAIBORobotSurface2",
-        "SyntheticControl",
-        "Trace",
-        "TwoLeadECG",
-    ]
-
-    num_folds = 30
-
-    import sktime.contrib.experiments as exp
-
-    for f in range(num_folds):
-        for d in small_datasets:
-            for c in complete_classifiers:
-                print(c, d, f)
-                try:
-                    exp.run_experiment(data_dir, res_dir, c, d, f)
-                    gc.collect()
-                    keras.backend.clear_session()
-                except:
-                    print('\n\n FAILED: ', sys.exc_info()[0], '\n\n')
-
-
 if __name__ == "__main__":
     all_networks_all_tests()

--- a/sktime_dl/classifiers/deeplearning/tests/test_dl4tscnetworks.py
+++ b/sktime_dl/classifiers/deeplearning/tests/test_dl4tscnetworks.py
@@ -1,8 +1,3 @@
-import gc
-import sys
-
-import keras
-
 from sktime.datasets import load_italy_power_demand #, load_basic_motions
 
 from sktime_dl.classifiers.deeplearning import CNNClassifier
@@ -77,8 +72,8 @@ def test_highLevelsktime(network=CNNClassifier()):
 
     print("start test_highLevelsktime()")
 
-    from sktime.highlevel import TSCTask
-    from sktime.highlevel import TSCStrategy
+    from sktime.highlevel.tasks import TSCTask
+    from sktime.highlevel.strategies import TSCStrategy
     from sklearn.metrics import accuracy_score
 
     train = load_italy_power_demand(split='TRAIN')

--- a/sktime_dl/experimental/reproductions.py
+++ b/sktime_dl/experimental/reproductions.py
@@ -1,0 +1,72 @@
+import gc
+import sys
+
+import keras
+from sktime.contrib.experiments import univariate_datasets
+
+from sktime_dl.classifiers.deeplearning import CNNClassifier
+from sktime_dl.classifiers.deeplearning import EncoderClassifier
+from sktime_dl.classifiers.deeplearning import FCNClassifier
+from sktime_dl.classifiers.deeplearning import MCDCNNClassifier
+from sktime_dl.classifiers.deeplearning import MCNNClassifier
+from sktime_dl.classifiers.deeplearning import MLPClassifier
+from sktime_dl.classifiers.deeplearning import ResNetClassifier
+from sktime_dl.classifiers.deeplearning import TLENETClassifier
+from sktime_dl.classifiers.deeplearning import TWIESNClassifier
+from sktime_dl.classifiers.deeplearning import TunedCNNClassifier
+
+def comparisonExperiments():
+    data_dir = sys.argv[1]
+    res_dir = sys.argv[2]
+
+    complete_classifiers = [
+        # "dl4tsc_cnn",
+        # "dl4tsc_encoder",
+        # "dl4tsc_fcn",
+        # "dl4tsc_mcdcnn",
+        # "dl4tsc_mcnn",
+        # "dl4tsc_mlp",
+        "dl4tsc_resnet",
+        # "dl4tsc_tlenet",
+        # "dl4tsc_twiesn",
+    ]
+
+    # small_datasets = [
+    #     "Beef",
+    #     "Car",
+    #     "Coffee",
+    #     "CricketX",
+    #     "CricketY",
+    #     "CricketZ",
+    #     "DiatomSizeReduction",
+    #     "Fish",
+    #     "GunPoint",
+    #     "ItalyPowerDemand",
+    #     "MoteStrain",
+    #     "OliveOil",
+    #     "Plane",
+    #     "SonyAIBORobotSurface1",
+    #     "SonyAIBORobotSurface2",
+    #     "SyntheticControl",
+    #     "Trace",
+    #     "TwoLeadECG",
+    # ]
+
+    num_folds = 30
+
+    import sktime.contrib.experiments as exp
+
+    for f in range(num_folds):
+        for d in univariate_datasets:
+            for c in complete_classifiers:
+                print(c, d, f)
+                try:
+                    exp.run_experiment(data_dir, res_dir, c, d, f)
+                    gc.collect()
+                    keras.backend.clear_session()
+                except:
+                    print('\n\n FAILED: ', sys.exc_info()[0], '\n\n')
+
+
+if __name__ == "__main__":
+    comparisonExperiments()

--- a/sktime_dl/experimental/reproductions.py
+++ b/sktime_dl/experimental/reproductions.py
@@ -19,8 +19,8 @@ def comparisonExperiments():
     data_dir = sys.argv[1]
     res_dir = sys.argv[2]
 
-    complete_classifiers = [
-        # "dl4tsc_cnn",
+    classifier_names = [
+        "dl4tsc_cnn",
         # "dl4tsc_encoder",
         # "dl4tsc_fcn",
         # "dl4tsc_mcdcnn",
@@ -29,6 +29,20 @@ def comparisonExperiments():
         "dl4tsc_resnet",
         # "dl4tsc_tlenet",
         # "dl4tsc_twiesn",
+        # "dl4tsc_tunedcnn"
+    ]
+
+    classifiers = [
+        CNNClassifier(),
+        # EncoderClassifier(),
+        # FCNClassifier(),
+        # MCDCNNClassifier(),
+        # MCNNClassifier(),
+        # MLPClassifier(),
+        ResNetClassifier(),
+        # TLENETClassifier(),
+        # TWIESNClassifier(),
+        # TunedCNNClassifier(),
     ]
 
     # small_datasets = [
@@ -58,10 +72,10 @@ def comparisonExperiments():
 
     for f in range(num_folds):
         for d in univariate_datasets:
-            for c in complete_classifiers:
-                print(c, d, f)
+            for cname, c in zip(classifier_names, classifiers):
+                print(cname, d, f)
                 try:
-                    exp.run_experiment(data_dir, res_dir, c, d, f)
+                    exp.run_experiment(data_dir, res_dir, cname, d, classifier=c, resampleID=f)
                     gc.collect()
                     keras.backend.clear_session()
                 except:

--- a/sktime_dl/experimental/reproductions.py
+++ b/sktime_dl/experimental/reproductions.py
@@ -21,50 +21,29 @@ def comparisonExperiments():
 
     classifier_names = [
         "dl4tsc_cnn",
-        # "dl4tsc_encoder",
-        # "dl4tsc_fcn",
-        # "dl4tsc_mcdcnn",
-        # "dl4tsc_mcnn",
-        # "dl4tsc_mlp",
+        "dl4tsc_encoder",
+        "dl4tsc_fcn",
+        "dl4tsc_mcdcnn",
+        "dl4tsc_mcnn",
+        "dl4tsc_mlp",
         "dl4tsc_resnet",
-        # "dl4tsc_tlenet",
-        # "dl4tsc_twiesn",
-        # "dl4tsc_tunedcnn"
+        "dl4tsc_tlenet",
+        "dl4tsc_twiesn",
+        "dl4tsc_tunedcnn"
     ]
 
     classifiers = [
         CNNClassifier(),
-        # EncoderClassifier(),
-        # FCNClassifier(),
-        # MCDCNNClassifier(),
-        # MCNNClassifier(),
-        # MLPClassifier(),
+        EncoderClassifier(),
+        FCNClassifier(),
+        MCDCNNClassifier(),
+        MCNNClassifier(),
+        MLPClassifier(),
         ResNetClassifier(),
-        # TLENETClassifier(),
-        # TWIESNClassifier(),
-        # TunedCNNClassifier(),
+        TLENETClassifier(),
+        TWIESNClassifier(),
+        TunedCNNClassifier(),
     ]
-
-    # small_datasets = [
-    #     "Beef",
-    #     "Car",
-    #     "Coffee",
-    #     "CricketX",
-    #     "CricketY",
-    #     "CricketZ",
-    #     "DiatomSizeReduction",
-    #     "Fish",
-    #     "GunPoint",
-    #     "ItalyPowerDemand",
-    #     "MoteStrain",
-    #     "OliveOil",
-    #     "Plane",
-    #     "SonyAIBORobotSurface1",
-    #     "SonyAIBORobotSurface2",
-    #     "SyntheticControl",
-    #     "Trace",
-    #     "TwoLeadECG",
-    # ]
 
     num_folds = 30
 

--- a/sktime_dl/experimental/reproductions.py
+++ b/sktime_dl/experimental/reproductions.py
@@ -15,7 +15,48 @@ from sktime_dl.classifiers.deeplearning import TLENETClassifier
 from sktime_dl.classifiers.deeplearning import TWIESNClassifier
 from sktime_dl.classifiers.deeplearning import TunedCNNClassifier
 
-def comparisonExperiments():
+import sktime.contrib.experiments as exp
+
+def setNetwork(cls, resampleId=0):
+    """
+    Basic way of determining the classifier to build. To differentiate settings just and another elif. So, for example, if
+    you wanted tuned TSF, you just pass TuneTSF and set up the tuning mechanism in the elif.
+    This may well get superceded, it is just how e have always done it
+    :param cls: String indicating which classifier you want
+    :return: A classifier.
+
+    """
+    if cls.lower() == 'dl4tsc_cnn':
+        return CNNClassifier()
+    elif cls.lower() == 'dl4tsc_encoder':
+        return EncoderClassifier()
+    elif cls.lower() == 'dl4tsc_fcn':
+        return FCNClassifier()
+    elif cls.lower() == 'dl4tsc_mcdcnn':
+        return MCDCNNClassifier()
+    elif  cls.lower() == 'dl4tsc_mcnn':
+        return MCNNClassifier()
+    elif cls.lower() == 'dl4tsc_mlp':
+        return MLPClassifier()
+    elif cls.lower() == 'dl4tsc_resnet':
+        return ResNetClassifier()
+    elif cls.lower() == 'dl4tsc_tlenet':
+        return TLENETClassifier()
+    elif cls.lower() == 'dl4tsc_twiesn':
+        return TWIESNClassifier()
+    elif cls.lower() == 'dl4tsc_tunedcnn':
+        return TunedCNNClassifier()
+    else:
+        raise Exception('UNKNOWN CLASSIFIER')
+
+def dlExperiment(data_dir, res_dir, classifier_name, dset, fold, classifier=None):
+
+    if classifier is None:
+        classifier = setNetwork(classifier_name, fold)
+
+    exp.run_experiment(data_dir, res_dir, classifier_name, dset, classifier=classifier, resampleID=fold)
+
+def allComparisonExperiments():
     data_dir = sys.argv[1]
     res_dir = sys.argv[2]
 
@@ -47,14 +88,12 @@ def comparisonExperiments():
 
     num_folds = 30
 
-    import sktime.contrib.experiments as exp
-
     for f in range(num_folds):
         for d in univariate_datasets:
             for cname, c in zip(classifier_names, classifiers):
                 print(cname, d, f)
                 try:
-                    exp.run_experiment(data_dir, res_dir, cname, d, classifier=c, resampleID=f)
+                    dlExperiment(data_dir, res_dir, cname, d, f, classifier=c)
                     gc.collect()
                     keras.backend.clear_session()
                 except:
@@ -62,4 +101,5 @@ def comparisonExperiments():
 
 
 if __name__ == "__main__":
-    comparisonExperiments()
+    #allComparisonExperiments()
+    dlExperiment(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], int(sys.argv[5]))


### PR DESCRIPTION
Been fairly out of it recently with sktime and this, but when going back to run some experiments today, I thought I'd pull sktime 0.3.0 and update sktime-dl to that standard

In short - 

* a couple of imports updated, e.g. tsctasks and strategy
* references to check_X_y removed (mloning to check, when I looked at a couple of classifiers in base sktime these had been removed since I last looked)
* updated the requirements in setup.py to sktime 0.3.0 as a dependency (from 0.2.0)